### PR TITLE
Latency tab addition

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from modules.utils import is_arabic, translate_text
 from modules.chat_explorer import show_chat_explorer
 from modules.search import show_keyword_search
 from modules.analytics import show_analytics_dashboard
+from modules.latency import show_latency_dashboard
 
 def main():
     st.set_page_config(page_title="Layla Conversation Analyzer", layout="wide")
@@ -108,7 +109,7 @@ def main():
     df = df[df['timestamp'] >= min_date]
 
     # Create tabs for different sections
-    tab1, tab2, tab3 = st.tabs(["Analytics Dashboard", "Chat Explorer", "Keyword Search"])
+    tab1, tab2, tab3, tab4 = st.tabs(["Analytics Dashboard", "Chat Explorer", "Keyword Search", "Response Latency"]) 
 
     with tab1:
         show_analytics_dashboard(df)
@@ -118,6 +119,9 @@ def main():
 
     with tab3:
         show_keyword_search(df)
+
+    with tab4:
+        show_latency_dashboard(df)
 
 if __name__ == "__main__":
     main()

--- a/modules/latency.py
+++ b/modules/latency.py
@@ -190,7 +190,8 @@ def _translate_text(s: str, enabled: bool) -> str:
         translated = translator.translate(str(s))
         cache[s] = translated
         return translated
-    except Exception:
+    except Exception as e:
+        st.warning(f"Translation failed: {e}")
         return s
 
 

--- a/modules/latency.py
+++ b/modules/latency.py
@@ -138,7 +138,8 @@ def _get_translator():
     if key not in st.session_state:
         try:
             st.session_state[key] = GoogleTranslator(source="auto", target="en")
-        except Exception:
+        except Exception as e:
+            logging.error(f"Failed to create GoogleTranslator: {type(e).__name__}: {e}")
             st.session_state[key] = None
     return st.session_state[key]
 

--- a/modules/latency.py
+++ b/modules/latency.py
@@ -342,47 +342,7 @@ def show_latency_dashboard(df: pd.DataFrame):
 
     st.divider()
 
-    # Which prompts take long to answer?
-    st.subheader("Prompts that took the longest to answer")
-    colp1, colp2 = st.columns([3, 1])
-    with colp1:
-        search_term = st.text_input("Filter by keyword in user prompt", key="latency_search_term")
-    with colp2:
-        min_latency_s = st.number_input("Min latency to include (s)", value=max(critical_threshold_s, 5), min_value=0, key="latency_min_latency")
-
-    prompt_df = lat_df.copy()
-    if search_term:
-        mask = prompt_df["user_message"].str.contains(str(search_term), case=False, na=False)
-        prompt_df = prompt_df[mask]
-    if min_latency_s > 0:
-        prompt_df = prompt_df[prompt_df["latency_seconds"] >= float(min_latency_s)]
-
-    if prompt_df.empty:
-        st.info("No prompts match the current filters.")
-    else:
-        st.dataframe(
-            prompt_df[
-                [
-                    "thread_id",
-                    "region",
-                    "user_timestamp",
-                    "assistant_timestamp",
-                    "latency_seconds",
-                    "user_word_len",
-                    "user_char_len",
-                    "user_message",
-                ]
-            ]
-            .sort_values("latency_seconds", ascending=False)
-            .assign(latency=lambda d: d["latency_seconds"].map(_format_seconds))
-            .drop(columns=["latency_seconds"]),
-            use_container_width=True,
-            hide_index=True,
-        )
-        st.caption("Use the filters to find slow prompts. Latency is the time the assistant took to reply to the shown user message.")
-
-    # Correlation: avg response time vs # messages per conversation
-    st.divider()
+    # Response time vs. conversation length (with outlier handling and explanation)
     st.subheader("Response time vs. conversation length")
     # Per thread metrics
     per_thread_counts = df_f.groupby("thread_id").size().rename("messages_count").reset_index()


### PR DESCRIPTION
- Focus the latency analysis on time from user message to the next assistant reply.
- Merge "Critical cases" and "Prompts that took the longest" into a single, clearer explorer.
- Add optional cleaning of assistant JSON and selective Arabic→English translation (only for visible rows).
- Add unique Streamlit widget keys to fix duplicate element ID errors.
- Improve readability with plain-language explanations and chart captions.
- Add outlier filtering (IQR) for the correlation chart.

## Changes
- `modules/latency.py`
  - Confirmed latency definition: user → next assistant reply within the same thread.
  - New helpers:
    - `_clean_assistant_message`: extracts human-readable text from assistant JSON (prefers `response_text`).
    - `_get_translator`, `_get_translation_cache`, `_translate_series`, `_translate_text`: on-demand translation with simple session cache.
  - Added global toggles:
    - Translate messages to English (off by default).
    - Clean assistant JSON to plain text (on by default).
  - Merged tables into "Slow replies explorer":
    - Filters: search in user prompt, min latency (seconds), toggle "Only show ≥ critical threshold", and Top N rows.
    - Column pickers for Region, User/Assistant timestamps, User word count, User message, Assistant message.
    - Latency displayed as the first column; assistant message (cleaned) included when selected.
    - Translate only displayed rows (uses cache).
  - "Extremes" section now shows cleaned/translated samples when toggled.
  - Charts:
    - Added captions to histogram and daily trend; clarified interpretations.
  - Correlation section:
    - Plain-language explanation of Pearson correlation.
    - Toggle to exclude outliers via IQR on avg latency; shows number removed and recomputes correlation/plot on filtered data.
  - Fixed duplicate widget IDs by giving all widgets unique keys.
  - Kept CSV download (per-answer latency) unchanged.